### PR TITLE
Documentation and provider update

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,20 +15,20 @@ Interact with [pfSense](https://www.pfsense.org/) firewall/router.
 ```terraform
 # self-signed Web GUI certificate
 provider "pfsense" {
-  host            = "https://192.168.1.1"
+  url             = "https://192.168.1.1"
   password        = var.pfsense_password
   tls_skip_verify = true
 }
 
 # trusted Web GUI certificate
 provider "pfsense" {
-  host     = "https://pfsense.lan"
+  url      = "https://pfsense.lan"
   password = var.pfsense_password
 }
 
 # custom user
 provider "pfsense" {
-  host     = "https://10.0.0.1"
+  url      = "https://10.0.0.1"
   username = "some-user"
   password = var.pfsense_password
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -210,6 +210,7 @@ func (p *pfSenseProvider) Configure(ctx context.Context, req provider.ConfigureR
 			"Unable to create pfSense client",
 			"An unexpected error occurred when creating the pfSense client. "+
 				"If the error is not clear, please contact the provider developers.\n\n"+
+				"pfSense client URL: "+opts.URL.String()+"\n"+
 				"pfSense client Error: "+err.Error(),
 		)
 		return


### PR DESCRIPTION
- Small update on documentation to use `url` instead of `host` (no longer the correct attributes)
- Small update to the error message to display the `url` that was passed to the `provider`
